### PR TITLE
Rename branch

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -402,7 +402,7 @@
 		</dict>
 	</dict>
 	<key>name</key>
-	<string>JavaScript jQuery</string>
+	<string>jQuery</string>
 	<key>ordering</key>
 	<array>
 		<string>1AD8EB10-62BE-417C-BC4B-29B5C6F0B36A</string>


### PR DESCRIPTION
Any chance of getting the bundle officially renamed from "Javascript jQuery" to just "jQuery"?
