### PR TITLE
.fadeToggle event autocompletion was pointing to .slideToggle

### DIFF
--- a/Snippets/fadeToggle.tmSnippet
+++ b/Snippets/fadeToggle.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>.slideToggle(${1/(^[0-9]+$)|.+/(?1::')/}${1:slow/400/fast}${1/(^[0-9]+$)|.+/(?1::')/})$0</string>
+	<string>.fadeToggle(${1/(^[0-9]+$)|.+/(?1::')/}${1:slow/400/fast}${1/(^[0-9]+$)|.+/(?1::')/})$0</string>
 	<key>name</key>
 	<string>fadeToggle</string>
 	<key>scope</key>


### PR DESCRIPTION
Hi Karl,

The .fadeToggle event autocompletion was pointing to .slideToggle event. I have fixed the issue. Let me know if there is anything else you want me to do for the change.

Thanks,
Mayank
